### PR TITLE
fix: upgrade jacoco plugin version to support Java 17 and spring boot upgrade to v3.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,7 @@
         <module>trpc-opentelemetry</module>
     </modules>
     <properties>
+        <java.version>17</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.test.skip>false</maven.test.skip>
         <maven.deploy.skip>false</maven.deploy.skip>
@@ -89,8 +90,8 @@
         <maven.source.version>3.0.1</maven.source.version>
         <maven.exec.version>3.0.1</maven.exec.version>
         <maven.jar.version>3.1.2</maven.jar.version>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.version>3.7.0</maven.compiler.version>
         <maven.gpg.version>3.1.0</maven.gpg.version>
         <maven.ignore.testfailure>false</maven.ignore.testfailure>
@@ -271,7 +272,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.6</version>
+                    <version>0.8.8</version>
                     <configuration>
                         <skip>false</skip>
                     </configuration>

--- a/trpc-demo/trpc-java-demo/pom.xml
+++ b/trpc-demo/trpc-java-demo/pom.xml
@@ -52,7 +52,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.6</version>
+                <version>0.8.8</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>

--- a/trpc-dependencies/trpc-dependencies-bom/pom.xml
+++ b/trpc-dependencies/trpc-dependencies-bom/pom.xml
@@ -99,9 +99,9 @@
         <slf4j.version>1.7.36</slf4j.version>
         <snakeyaml.version>2.0</snakeyaml.version>
         <snappy.version>1.1.10.4</snappy.version>
-        <spring.version>6.2.2</spring.version>
-        <springboot.version>3.4.2</springboot.version>
-        <spring.cloud.gateway.version>4.2.1</spring.cloud.gateway.version>
+        <spring.version>6.2.7</spring.version>
+        <springboot.version>3.5.0</springboot.version>
+        <spring.cloud.gateway.version>4.3.0</spring.cloud.gateway.version>
         <transmittable.version>2.12.4</transmittable.version>
         <zookeeper.version>3.8.4</zookeeper.version>
 


### PR DESCRIPTION
fix: upgrade jacoco plugin version to support Java 17 and spring boot upgrade to v3.5.0